### PR TITLE
Add documentation to the crate, remove ambiguous return value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "match_all"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sebastian Malton <snmalton@edu.uwaterloo.ca>", "Josh Leverette <coder543@gmail.com>"]
 description = "This crate provides a match_all! macro for matching multiple patterns"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,47 +1,55 @@
 # match_all
-Provides the match_all! macro for rust
+Provides the `match_all!` macro for rust
 
 This macro provides similar functionality to a vanilla `match` statement but allows for multiple expression blocks to be executed.
 
-Format:
+## Format
+
 ```rust
-match_all!{
-    value,
+match_all!{ value,
     IfNoMatch => expr,
     pat | pat ... => expr,
     ...
 }
 ```
-* `value`: is the value that is wished to be matched on, this can be any function or variable that reduces to a value
+
+* `value`: the expression to match on.
 * `IfNoMatch`: the expression after this is executed if none of the other patterns are matched. This branch is optional.
 * `pat | pat ...`: this is groupings of patterns that will be checked. If any of them match to value then their corresponding expression is executed. After checking a group of patterns then the next group is checked until all groups have been checked. If none match then the `IfNoMatch` expression will be executed.
 
-This can be used to set values of a variable but the following must hold:
+## Example One
 
-1. The `IfNoMatch` block must be present
-
-Examples:
-
-1.
 ```rust
-    let value = Some(4);
+let value = Some(4);
 
-    match_all!{ value,
-        None => println!("Hi"),
-        Some(3) | Some(4) => println!("Hello"),
-        Some(4) | Some(5) => println!("Howdy")
-    }
-
-    > Hello
-    > Howdy
+match_all!{ value,
+    None => println!("Hi"),
+    Some(3) | Some(4) => println!("Hello"),
+    Some(4) | Some(5) => println!("Howdy")
+}
 ```
-2.
+
+This would print:
+
+```
+Hello
+Howdy
+```
+
+## Example Two
+
 ```rust
-    let x = match_all!{ some_fn(),
-        IfNoMatch => {
-            println!("No Match");
-            false
-        }
-        0..4 => true
-    };
+let value = Some(20);
+match_all!{ value,
+    IfNoMatch => println!("No Match"),
+    0..4 => println!("Between 0 and 4")
+};
 ```
+
+This would print:
+
+```
+No Match
+```
+
+It prints this because it uses the special `IfNoMatch` expression to provide an expression that matches only when no other expression was matched.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Howdy
 let value = Some(20);
 match_all!{ value,
     IfNoMatch => println!("No Match"),
-    0..4 => println!("Between 0 and 4")
+    0...4 => println!("0 through 4")
 };
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //!     let value = Some(20);
 //!     match_all!{ value,
 //!         IfNoMatch => println!("No Match"),
-//!         0..4 => println!("Between 0 and 4")
+//!         0...4 => println!("0 through 4")
 //!     };
 //!
 //! This would print:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,50 @@
+//! # match_all
+//! Provides the `match_all!` macro for rust
+//!
+//! This macro provides similar functionality to a vanilla `match` statement but allows for multiple expression blocks to be executed.
+//!
+//! ## Format
+//!
+//!     match_all!{ value,
+//!         IfNoMatch => expr,
+//!         pat | pat ... => expr,
+//!         ...
+//!     }
+//!
+//! * `value`: the expression to match on.
+//! * `IfNoMatch`: the expression after this is executed if none of the other patterns are matched. This branch is optional.
+//! * `pat | pat ...`: this is groupings of patterns that will be checked. If any of them match to value then their corresponding expression is executed. After checking a group of patterns then the next group is checked until all groups have been checked. If none match then the `IfNoMatch` expression will be executed.
+//!
+//! ## Example One
+//!
+//!     let value = Some(4);
+//!
+//!     match_all!{ value,
+//!         None => println!("Hi"),
+//!         Some(3) | Some(4) => println!("Hello"),
+//!         Some(4) | Some(5) => println!("Howdy")
+//!     }
+//!
+//! This would print:
+//!
+//!     Hello
+//!     Howdy
+//!
+//! ## Example Two
+//!
+//!     let value = Some(20);
+//!     match_all!{ value,
+//!         IfNoMatch => println!("No Match"),
+//!         0..4 => println!("Between 0 and 4")
+//!     };
+//!
+//! This would print:
+//!
+//!     No Match
+//!
+//! It prints this because it uses the special `IfNoMatch` expression to provide an expression that matches only when no other expression was matched.
+
+
 #[macro_export]
 macro_rules! match_all {
    ($val:expr, IfNoMatch => $c:expr, $($($p:pat)|+ => $b:expr),+) => {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,26 +48,22 @@
 #[macro_export]
 macro_rules! match_all {
    ($val:expr, IfNoMatch => $c:expr, $($($p:pat)|+ => $b:expr),+) => {{
-        unsafe {
-            let val = $val;
-            let mut matched = false;
-            let mut ret = mem::uninitialized();
-            $(
-                loop {
-                    $(
-                        if let $p = val {
-                            matched = true;
-                            ret = $b;
-                            break
-                        }
-                    )+
-                    break
-                }
-            )+
-            if !matched {
-                ret = $c;
+        let val = $val;
+        let mut matched = false;
+        $(
+            loop {
+                $(
+                    if let $p = val {
+                        matched = true;
+                        $b;
+                        break
+                    }
+                )+
+                break
             }
-            ret
+        )+
+        if !matched {
+            $c;
         }
    }};
    ($val:expr, $($($p:pat)|+ => $b:expr),+) => {{


### PR DESCRIPTION
This adds documentation directly to the crate itself.

I also don't believe it is a good idea to return a value from `match_all!`, because it will arbitrarily return the value of the last expression that was matched. We could be matching half a dozen branches, and it would be _surprising_ behavior to just get the expression result of one of them.